### PR TITLE
Updated for case sensitivity (OSK-5)

### DIFF
--- a/src/OSK.Extensions.Serialization.SysTextJson.Polymorphism.UnitTests/PolymorphismJsonConverterTests.cs
+++ b/src/OSK.Extensions.Serialization.SysTextJson.Polymorphism.UnitTests/PolymorphismJsonConverterTests.cs
@@ -8,8 +8,10 @@ using OSK.Serialization.Polymorphism;
 using OSK.Serialization.Polymorphism.Discriminators;
 using OSK.Serialization.Polymorphism.Models;
 using OSK.Serialization.Polymorphism.Ports;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using System.Text.Unicode;
 using Xunit;
 
 namespace OSK.Extensions.Serialization.SysTextJson.Polymorphism.UnitTests
@@ -57,7 +59,7 @@ namespace OSK.Extensions.Serialization.SysTextJson.Polymorphism.UnitTests
         #region End to End
 
         [Fact]
-        public async void Validate_ServiceCollectionExtensions()
+        public async Task Validate_ServiceCollectionExtensions()
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddSystemTextJsonSerialization();
@@ -92,6 +94,65 @@ namespace OSK.Extensions.Serialization.SysTextJson.Polymorphism.UnitTests
             var serializer = provider.GetRequiredService<IJsonSerializer>();
             var data = await serializer.SerializeAsync(items);
             _ = await serializer.DeserializeAsync(data, items.GetType());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Deserialization_JsonSerializationOptionCaseSensitivityValidation_ReturnsExpectedResult(bool enforceCaseSensitivity)
+        {
+            // Arrange
+            var mockEnumStrategy = new Mock<IPolymorphismEnumDiscriminatorStrategy>();
+            mockEnumStrategy.Setup(m => m.GetConcreteType(It.IsAny<PolymorphismAttribute>(),
+                It.IsAny<Type>(), It.IsAny<object>()))
+                .Returns((PolymorphismAttribute attribute, Type typeToConvert, object currentValue) =>
+                {
+                    switch (currentValue)
+                    {
+                        case 0:
+                            return typeof(TestChildA);
+                        case 1:
+                            return typeof(TestChildB);
+                        default:
+                            throw new InvalidCastException("Current value not an expected abstract type");
+                    }
+                });
+
+            var context = new PolymorphismContext(
+                PolymorphismAttribute.GetPolymorphismAttribute(typeof(TestAbstract)),
+                typeof(TestAbstract),
+                mockEnumStrategy.Object
+                );
+
+            _mockContextProvider.Setup(m => m.HasPolymorphismStrategy(It.Is<Type>(t => t == typeof(TestAbstract))))
+                .Returns(true);
+            _mockContextProvider.Setup(m => m.GetPolymorphismContext(It.Is<Type>(t => t == typeof(TestAbstract))))
+                .Returns(context);
+
+            var itemJson = $"[{{ \"A\": 1, \"B\": [ 1, 2, 3 ], \"Today\": \"2024-12-10T23:29:28.067736-05:00\", \"aBsTrAcTtYpE\": 0}}]";
+
+            var serializerOptions = new JsonSerializerOptions()
+            {
+                PropertyNameCaseInsensitive = !enforceCaseSensitivity,
+                WriteIndented = true,
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+            };
+            serializerOptions.Converters.Add(_converter);
+            serializerOptions.MakeReadOnly();
+            using var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(itemJson));
+
+            // Act
+
+            memoryStream.Position = 0;
+            try
+            {
+                _ = JsonSerializer.Deserialize(memoryStream, typeof(IEnumerable<TestAbstract>), serializerOptions);
+                Assert.False(enforceCaseSensitivity);
+            }
+            catch (Exception ex)
+            {
+                Assert.True(enforceCaseSensitivity);
+            }
         }
 
         [Fact]

--- a/src/OSK.Extensions.Serialization.SystemTextJson.Polymorphism/OSK.Extensions.Serialization.SystemTextJson.Polymorphism.csproj
+++ b/src/OSK.Extensions.Serialization.SystemTextJson.Polymorphism/OSK.Extensions.Serialization.SystemTextJson.Polymorphism.csproj
@@ -19,7 +19,7 @@
 
 	<ItemGroup>
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
-		<PackageReference Include="OSK.Extensions.SystemTextJson.Common" Version="1.0.2" />
+		<PackageReference Include="OSK.Extensions.SystemTextJson.Common" Version="1.1.0" />
 		<PackageReference Include="OSK.Serialization.Polymorphism" Version="1.0.0" />
 	</ItemGroup>
 

--- a/src/OSK.Extensions.Serialization.SystemTextJson.Polymorphism/PolymorphismJsonConverter.cs
+++ b/src/OSK.Extensions.Serialization.SystemTextJson.Polymorphism/PolymorphismJsonConverter.cs
@@ -33,7 +33,8 @@ namespace OSK.Extensions.Serialization.SystemTextJson.Polymorphism
         public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             var polymorphismContext = _polymorphismContextProvider.GetPolymorphismContext(typeToConvert);
-            var polymorphicPropertyValue = GetPolymorphismPropertyValue(ref reader, polymorphismContext.PolymorphismPropertyName, typeToConvert);
+            var polymorphicPropertyValue = GetPolymorphismPropertyValue(ref reader, polymorphismContext.PolymorphismPropertyName,
+                options.PropertyNameCaseInsensitive, typeToConvert);
             if (polymorphicPropertyValue == null)
             {
                 throw new InvalidOperationException($"Failed to deserialize object of type {typeToConvert.FullName} because the expected polymorphic property, {polymorphismContext.PolymorphismPropertyName}, was not found in the JSON stream.");
@@ -57,9 +58,10 @@ namespace OSK.Extensions.Serialization.SystemTextJson.Polymorphism
 
         #region Helpers
 
-        private object GetPolymorphismPropertyValue(ref Utf8JsonReader reader, string propertyName, Type typeToConvert)
+        private object GetPolymorphismPropertyValue(ref Utf8JsonReader reader, string propertyName,
+            bool ignoreCaseSensitivity, Type typeToConvert)
         {
-            if (!reader.TryFindPropertyValue(propertyName, out var propertyReader))
+            if (!reader.TryFindPropertyValue(propertyName, ignoreCaseSensitivity, out var propertyReader))
             {
                 throw new InvalidOperationException($"Failed to deserialize object of type {typeToConvert.FullName} because the expected polymorphic property, {propertyName}, was not found in the JSON stream.");
             }


### PR DESCRIPTION
Motivation
----
Current package fails to find property names if they aren't matching case. This should be based on the JsonSerializationOptions rather than asusmed

Modifications
----
* Updated package for Utf8JsonReaderExtensions which includes new overload for case sensitivity
* Updated PolymorphismJsonConverter to use new extension
* Added UnitTest to validate failing use case is passing

Result
----
Case sensitivity on deserialization is respected based on JsonSerializationOptions settings

Fixes #5